### PR TITLE
Improve handling of issue time, ensure last updated minutes has 2 characters, fix dual "Last updated" string, sort issues by most recent activity

### DIFF
--- a/gitissues.widget/index.jsx
+++ b/gitissues.widget/index.jsx
@@ -77,7 +77,7 @@ export const render = (state) => (
           })}
         </tbody>
       </table>
-      <p className={infoTag}>Last Updated {state.lastChecked}</p>
+      <p className={infoTag}>{state.lastChecked}</p>
     </div>
   ))
 
@@ -113,16 +113,22 @@ export const updateState = (event, previousState) => {
   }
   // What we need now is to fetch the issues and display them.
   let current = new Date()
-  let lastChecked = 'Last updated on ' + `${monNames[current.getMonth()]} ${current.getDate()}, ${current.getFullYear()}, ${current.getHours()}:${current.getMinutes()}`
+  let lastChecked = 'Last updated on ' + `${monNames[current.getMonth()]} ${current.getDate()}, ${current.getFullYear()}, ${current.getHours()}:${String(current.getMinutes()).padStart(2, "0")}`
   // Reset the issues to overwrite old ones
   previousState.displayIssues = []
   for (let issue of event.data) {
-    if (issue.state === 'open') {
+    if (issue.state === 'open') { 
       let t = Date.parse(issue.updated_at)
-      if (Date.now() - t < 86400000) {
-        t = 'yesterday'
-      } else if (Date.now() - t < 604800000) {
-        t = 'last week'
+      let now = Date.now()
+      let elapsed = now - t
+      if (elapsed < 86400000) {
+        if (elapsed < 3600000){
+          t = Math.floor(elapsed / 60000) + " Minute(s) ago"
+        } else {
+          t = Math.floor(elapsed / 3600000) + " Hour(s) ago"
+        }
+      } else if (elapsed < 604800000) {
+        t = 'Within last week'
       } else {
         t = new Date(t)
         t = 'on ' + `${monNames[t.getMonth()]} ${t.getDate()}, ${t.getFullYear()}`

--- a/gitissues.widget/index.jsx
+++ b/gitissues.widget/index.jsx
@@ -140,11 +140,13 @@ export const updateState = (event, previousState) => {
         'user': issue.user.login,
         'comments': issue.comments,
         'labels': issue.labels.map((l) => { return { 'name': l.name, 'color': l.color } }),
-        'time': t
+        'time': t,
+        'elapsed': elapsed
       })
     }
   }
 
+  previousState.displayIssues = previousState.displayIssues.sort((e1, e2) => (e1.elapsed > e2.elapsed) ? 1 : (e1.elapsed < e2.elapsed) ? -1 : 0)
   previousState.displayIssues = previousState.displayIssues.slice(0, 10) // Only leave 10 issues
   previousState.lastChecked = lastChecked
   return previousState

--- a/gitissues.widget/index.jsx
+++ b/gitissues.widget/index.jsx
@@ -126,9 +126,9 @@ export const updateState = (event, previousState) => {
       let timeDelta = now - issueUpdated
       if (timeDelta < 86_400_000) {
         if (timeDelta < 3_600_000){
-          issueUpdated = Math.floor(elapsed / 60_000) + " Minute(s) ago"
+          issueUpdated = Math.floor(timeDelta / 60_000) + " Minute(s) ago"
         } else {
-          issueUpdated = Math.floor(elapsed / 3_600_000) + " Hour(s) ago"
+          issueUpdated = Math.floor(timeDelta / 3_600_000) + " Hour(s) ago"
         }
       } else if (timeDelta < 604_800_000) {
         issueUpdated = 'Within last week'


### PR DESCRIPTION
This PR includes several changes.

1. Previously, Issues updated within the last 24 hours always returned "yesterday". Now, if it has been less than 24 hours: 
  ** The time displayed will be in minutes when less than 1 hour ago.
  ** In hours if less than 24 hours ago, but >= 1 hour.

2. Last updated field previously displayed "Last updated" twice. This has now been fixed.

3. Padded the widget's last updated on minute value with "0" if the minute value is < 10. Prior to this change, a time of 22:04 would be incorrectly displayed as 22:4.

Example:

Before:
![image](https://user-images.githubusercontent.com/52541649/230745362-9fefbe5a-9b99-42f2-8291-78361f89c7ee.png)


After:
![image](https://user-images.githubusercontent.com/52541649/230745372-f053eff5-5b98-425f-a076-ace841702721.png)


4. Issues are now sorted depending on the most recent activity.

Example:

Before:
![image](https://user-images.githubusercontent.com/52541649/230745453-4d456100-11fc-4b95-b1c0-a1874e96969b.png)


After:
![image](https://user-images.githubusercontent.com/52541649/230745461-1027a863-00ca-4871-92af-2acfca1275eb.png)
